### PR TITLE
Wrap `with_dict` arguments with "{{ }}"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,7 @@
               state={{item.value.state | default('present')}}
               priv="{{item.value.priv | default('*.*:USAGE')}}"
               append_privs={{item.value.append_privs | default('no')}}
-  with_dict: mysql_users | default({})
+  with_dict: "{{ mysql_users | default({}) }}"
 
 - name: Manage mysql databases
   mysql_db: login_user={{mysql_login_user}}
@@ -76,5 +76,4 @@
             name="{{item.key}}"
             state={{item.value.state | default('present')}}
             target={{item.value.target | default()}}
-  with_dict: mysql_dbs | default({})
-
+  with_dict: "{{ mysql_dbs | default({}) }}"


### PR DESCRIPTION
Hi!

Without the wrapping, the default filter doesn't get applied and the run fails whenever the var is undefined.

Here's the output with added debug statements 
```
TASK [mysql : debug] ***********************************************************
ok: [default] => {
    "mysql_users": "VARIABLE IS NOT DEFINED!"
}

TASK [mysql : Manage mysql users] **********************************************
fatal: [default]: FAILED! => {"failed": true, "msg": "with_dict expects a dict"}
	...
```
Misc info about the system:
```
$ ansible --version
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

$ uname -a (on the host)
Linux ... 4.4.0-93-generic #116-Ubuntu SMP Fri Aug 11 21:17:51 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux

$ uname -a (on the target, a VirtualBox VM)
Linux ... 4.4.0-93-generic #116-Ubuntu SMP Fri Aug 11 21:17:51 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux

```